### PR TITLE
feat(types): Allow `timeout` option in `waitForOutput`

### DIFF
--- a/src/scenarioBuilder.ts
+++ b/src/scenarioBuilder.ts
@@ -1,5 +1,10 @@
 import { spawn } from "child_process";
-import { Actions, InteractionBuilder, TestEnv } from "./types.js";
+import {
+  Actions,
+  ExpectOutputOptions,
+  InteractionBuilder,
+  TestEnv,
+} from "./types.js";
 
 const DEFAULT_STEP_TIMEOUT = 10_000;
 
@@ -13,6 +18,7 @@ type Step = { id: number; timeout?: number } & (
   | {
       type: "output";
       output: string;
+      timeout?: number;
     }
 );
 
@@ -47,7 +53,7 @@ export class ScenarioBuilder implements InteractionBuilder {
    */
   whenAsked(
     stdout: string,
-    opts?: { timeout?: number }
+    opts?: ExpectOutputOptions
   ): {
     respondWith: (...response: string[]) => InteractionBuilder;
   } {
@@ -76,10 +82,7 @@ export class ScenarioBuilder implements InteractionBuilder {
    * @param stdout - The specific `stdout` CLI output to expect.
    * @param opts - Optional timeout (default is 5 seconds).
    */
-  expectOutput(
-    output: string,
-    opts?: { timeout?: number }
-  ): InteractionBuilder {
+  expectOutput(output: string, opts?: ExpectOutputOptions): InteractionBuilder {
     this.#steps.push({
       id: this.#stepCount++,
       type: "output",

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,15 +3,26 @@ export type Actions = {
   expectOutput: InteractionBuilder["expectOutput"];
 };
 
+export interface ExpectOutputOptions {
+  /**
+   * The number of milliseconds to wait for the output to be emitted.
+   * @default 5000 (5s)
+   */
+  timeout?: number;
+}
+
 export interface InteractionBuilder {
   whenAsked: (
     prompt: string,
-    opts?: { timeout?: number }
+    opts?: ExpectOutputOptions
   ) => {
     respondWith: (...response: string[]) => InteractionBuilder;
   };
 
-  expectOutput: (output: string) => InteractionBuilder;
+  expectOutput: (
+    output: string,
+    opts?: ExpectOutputOptions
+  ) => InteractionBuilder;
 
   step: (
     name: string,


### PR DESCRIPTION
this was already supported but types didn't reflect it